### PR TITLE
Fix Linux Connection issues without `sudo` permissions

### DIFF
--- a/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
+++ b/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
@@ -102,7 +102,7 @@ PveTicket. Return ticket connection.
 
             if ($data.Length -eq 2 ) { [int32]::TryParse($data[1] , [ref]$portTmp) | Out-Null }
 
-            if (Test-Connection -Ping $hostTmp -BufferSize 16 -Count 1 -ea 0 -quiet) {
+            if (Test-Connection -Ping $hostTmp -Count 1 -ea 0 -quiet) {
                 $hostName = $hostTmp;
                 $port = $portTmp;
                 break;


### PR DESCRIPTION
Fixes #19

```powershell
PS > Connect-PveCluster -Credentials root -HostsAndPorts 192.168.1.1:8006 -SkipCertificateCheck

PowerShell credential request
Enter your credentials.
Password for user root: ************************


HostName             : 192.168.1.1
Port                 : 8006
SkipCertificateCheck : True
Ticket               : PVE:root@pam:xxxx==
CSRFPreventionToken  : xxxx
ApiToken             : 
```