### PR TITLE
Add_parameter_for_additional_args

### DIFF
--- a/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
+++ b/Corsinvest.ProxmoxVE.Api/Corsinvest.ProxmoxVE.Api.psm1
@@ -467,6 +467,8 @@ The (unique) ID or Name of the VM.
 Path of Spice remove viewer.
 - Linux /usr/bin/remote-viewer
 - Windows C:\Program Files\VirtViewer v?.?-???\bin\remote-viewer.exe
+.PARAMETER AdditonalArgs
+Additional arguments that should be passed to the remote viewer application
 .OUTPUTS
 PveResponse. Return response.
 #>
@@ -482,7 +484,10 @@ PveResponse. Return response.
 
         [Parameter(Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
-        [string]$Viewer
+        [string]$Viewer,
+
+        [ValidateNotNullOrEmpty()]
+        [string]$AdditionalArgs
     )
 
     process {
@@ -504,7 +509,7 @@ PveResponse. Return response.
             $tmp = New-TemporaryFile
             $ret.Response | Out-File $tmp.FullName
 
-            Start-Process -FilePath $Viewer -Args $tmp.FullName
+            Start-Process -FilePath $Viewer -Args "$($tmp.FullName) $AdditionalArgs"
         }
     }
 }


### PR DESCRIPTION
I use this powershell module in a big project that I am working on at work, but one of the requirements for this project is to launch the spice client in full screen mode.  There are, of course, arguments that can be passed to the remote viewer application that would allow for this, but no way to do so within in the powershell module.  This pull request simply adds an additional parameter to the "Invoke-PveSpice" function named "AdditionalArgs", which allow the user to optionally pass additional arguments to the command which launches the viewer application defined in the function.  The modifications contained within this pull request are the same modifications that I have already made to this module that I use for my project, and it works perfectly.  